### PR TITLE
Enforce no space around properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
   ],
   rules: {
     semi: [2, 'always'],
+    'no-whitespace-before-property': 1,
     'dot-notation': 2,
     eqeqeq: [2, 'smart'],
     'brace-style': [2, '1tbs', {allowSingleLine: true}],


### PR DESCRIPTION
Recently I broke some stuff in the iOS driver because of a `.` instead of a `,`. This rule will enforce no spaces between an object, the `.`, and the property.

Turn it on "warning" for now, so we just be told, but builds will not fail.