### PR TITLE
Update to latest eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ This config requires the following packages be installed (as dev dependencies) i
 
 * [babel-eslint](https://www.npmjs.com/package/babel-eslint)
 * [eslint](https://www.npmjs.com/package/eslint)
-* [eslint-plugin-babel](https://www.npmjs.com/package/eslint-plugin-babel)
 * [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import)
 * [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha)
 * (eslint-plugin-promise)(https://www.npmjs.com/package/eslint-plugin-promise)

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = {
     es6: true
   },
   plugins: [
-    "babel",
     "import",
     "mocha",
     "promise"
@@ -33,11 +32,11 @@ module.exports = {
     'comma-dangle': 0,
     'no-empty': 0,
     'space-before-function-paren': [2, 'always'],
-    'space-before-blocks': [1, 'always'],
-    'space-in-parens': [1, 'never'],
-    'babel/array-bracket-spacing': 1,
-    'babel/object-shorthand': 1,
-    'babel/arrow-parens': 1,
+    'space-before-blocks': [2, 'always'],
+    'space-in-parens': [2, 'never'],
+    'array-bracket-spacing': 2,
+    'object-shorthand': 2,
+    'arrow-parens': 2,
     'import/export': 2,
     'import/no-unresolved': 2,
     'import/no-duplicates': 2,

--- a/package.json
+++ b/package.json
@@ -24,19 +24,18 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "peerDependencies": {
-    "babel-eslint": "^6.0.4",
-    "eslint": "^2.12.0",
-    "eslint-plugin-babel": "^3.2.0",
-    "eslint-plugin-import": "^1.8.1",
-    "eslint-plugin-mocha": "^3.0.0"
+    "babel-eslint": "^7.1.1",
+    "eslint": "^3.10.2",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-mocha": "^4.7.0",
+    "eslint-plugin-promise": "^3.3.1"
   },
   "devDependencies": {
-    "babel-eslint": "^6.0.4",
-    "eslint": "^2.12.0",
-    "eslint-find-rules": "^1.10.0",
-    "eslint-plugin-babel": "^3.2.0",
-    "eslint-plugin-import": "^1.8.1",
-    "eslint-plugin-mocha": "^3.0.0",
+    "babel-eslint": "^7.1.1",
+    "eslint": "^3.10.2",
+    "eslint-find-rules": "^1.14.3",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-promise": "^3.3.1"
   }
 }


### PR DESCRIPTION
Update to eslint 3 (since 2 is no longer supported). Also change warnings on some of the style things to be errors.

This will be a breaking change, and should cause a major version bump.