### PR TITLE
Add rule to disallow var

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
   ],
   rules: {
     semi: [2, 'always'],
-    radix: [1, 'always'], // just warn, for now
+    radix: [2, 'always'],
     'no-whitespace-before-property': 2,
     'dot-notation': 2,
     eqeqeq: [2, 'smart'],
@@ -49,6 +49,7 @@ module.exports = {
     "promise/prefer-await-to-callbacks": 1,
     "require-await": 2,
     "no-trailing-spaces": 2,
+    "no-var": 2,
   },
   extends: [
     'eslint:recommended'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint": "^3.10.2",
+    "eslint": "^3.16.1",
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-mocha": "^4.7.0",


### PR DESCRIPTION
So that people are notified when they try to use `var`.

Next time this is published it will be a major version because the addition of `require-await` is breaking ([requiring](http://eslint.org/docs/rules/require-await#version) `eslint` 3.11.0).