### PR TITLE
Add rules for spaces around things

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,20 +21,12 @@ module.exports = {
   rules: {
     semi: [2, 'always'],
     radix: [2, 'always'],
-    'no-whitespace-before-property': 2,
     'dot-notation': 2,
     eqeqeq: [2, 'smart'],
     'brace-style': [2, '1tbs', {allowSingleLine: true}],
-    'comma-spacing': [2, {before: false, after: true}],
     indent: [2, 2, {VariableDeclarator: {var: 2, let: 2, const: 3}, SwitchCase: 1}],
-    'arrow-spacing': 2,
-    'keyword-spacing': 2,
     'comma-dangle': 0,
     'no-empty': 0,
-    'space-before-function-paren': [2, 'always'],
-    'space-before-blocks': [2, 'always'],
-    'space-in-parens': [2, 'never'],
-    'array-bracket-spacing': 2,
     'object-shorthand': 2,
     'arrow-parens': 2,
     'import/export': 2,
@@ -48,8 +40,26 @@ module.exports = {
     "promise/prefer-await-to-then": 1,
     "promise/prefer-await-to-callbacks": 1,
     "require-await": 2,
-    "no-trailing-spaces": 2,
     "no-var": 2,
+    curly: [2, "multi-or-nest", "consistent"]
+
+    // enforce spacing
+    "arrow-spacing": 2,
+    "keyword-spacing": 2,
+    "comma-spacing": [2, {
+      before: false,
+      after: true
+    }],
+    "array-bracket-spacing": 2,
+    "no-trailing-spaces": 2,
+    "no-whitespace-before-property": 2,
+    "space-in-parens": [2, "never"],
+    "space-before-blocks": [2, "always"],
+    "space-before-function-paren": [2, "always"],
+    "space-unary-ops": [2, {
+      "words": true,
+      "nonwords": false,
+    }]
   },
   extends: [
     'eslint:recommended'


### PR DESCRIPTION
Better enforcement of space. Add rules for [inside parentheses](http://eslint.org/docs/rules/space-in-parens), [before blocks](http://eslint.org/docs/rules/space-before-blocks), and [unary operators](http://eslint.org/docs/rules/space-unary-ops). Also add a rule to enforce [curly braces](http://eslint.org/docs/rules/curly).