### PR TITLE
Warn when using arrow functions in mocha tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = {
     'import/no-unresolved': 2,
     'import/no-duplicates': 2,
     'mocha/no-exclusive-tests': 2,
+    'mocha/no-mocha-arrows': 1, // warn for arrow functions in mocha
     "promise/no-return-wrap": 1,
     "promise/param-names": 1,
     "promise/catch-or-return": 1,


### PR DESCRIPTION
Add a warning when passing in arrow functions to mocha, since this can adversely affect test functioning.

Once all the packages don't do this, we can change to an error so new ones don't creep in.