### PR TITLE
Update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ This config requires the following packages be installed (as dev dependencies) i
 * [eslint](https://www.npmjs.com/package/eslint)
 * [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import)
 * [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha)
-* (eslint-plugin-promise)(https://www.npmjs.com/package/eslint-plugin-promise)
+* [eslint-plugin-promise](https://www.npmjs.com/package/eslint-plugin-promise)

--- a/index.js
+++ b/index.js
@@ -1,22 +1,22 @@
 module.exports = {
-  parser: "babel-eslint",
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 6,
-    sourceType: "module",
+    sourceType: 'module',
     ecmaFeatures: {
       impliedStrict: true,
-      experimentalObjectRestSpread: true
+      experimentalObjectRestSpread: true,
     },
   },
   env: {
     node: true,
     mocha: true,
-    es6: true
+    es6: true,
   },
   plugins: [
-    "import",
-    "mocha",
-    "promise"
+    'import',
+    'mocha',
+    'promise',
   ],
   rules: {
     semi: [2, 'always'],
@@ -28,41 +28,40 @@ module.exports = {
     'comma-dangle': 0,
     'no-empty': 0,
     'object-shorthand': 2,
-    // 'arrow-parens': 2, // TODO: fix when they figure out async functions
     'import/export': 2,
     'import/no-unresolved': 2,
     'import/no-duplicates': 2,
     'mocha/no-exclusive-tests': 2,
-    'mocha/no-mocha-arrows': 1, // warn for arrow functions in mocha
-    "promise/no-return-wrap": 1,
-    "promise/param-names": 1,
-    "promise/catch-or-return": 1,
-    "promise/no-native": 1,
-    "promise/prefer-await-to-then": 1,
-    "promise/prefer-await-to-callbacks": 1,
-    // "require-await": 2, // TODO: update when we have time to get eslint upgraded throughout
-    "no-var": 2,
+    'mocha/no-mocha-arrows': 2,
+    'promise/no-return-wrap': 1,
+    'promise/param-names': 1,
+    'promise/catch-or-return': 1,
+    'promise/no-native': 1,
+    'promise/prefer-await-to-then': 1,
+    'promise/prefer-await-to-callbacks': 1,
+    'require-await': 2,
+    'no-var': 2,
     curly: [2, "all"],
 
     // enforce spacing
-    "arrow-spacing": 2,
-    "keyword-spacing": 2,
-    "comma-spacing": [2, {
+    'arrow-spacing': 2,
+    'keyword-spacing': 2,
+    'comma-spacing': [2, {
       before: false,
       after: true
     }],
-    "array-bracket-spacing": 2,
-    "no-trailing-spaces": 2,
-    "no-whitespace-before-property": 2,
-    "space-in-parens": [2, "never"],
-    "space-before-blocks": [2, "always"],
-    "space-before-function-paren": [2, "always"],
-    "space-unary-ops": [2, {
+    'array-bracket-spacing': 2,
+    'no-trailing-spaces': 2,
+    'no-whitespace-before-property': 2,
+    'space-in-parens': [2, 'never'],
+    'space-before-blocks': [2, 'always'],
+    'space-before-function-paren': [2, 'always'],
+    'space-unary-ops': [2, {
       words: true,
       nonwords: false,
     }],
   },
   extends: [
-    'eslint:recommended'
-  ]
-}
+    'eslint:recommended',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "peerDependencies": {
-    "babel-eslint": "^7.1.1",
-    "eslint": "^3.10.2",
+    "babel-eslint": "^8.2.1",
+    "eslint": "^4.17.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-promise": "^3.3.1"
   },
   "devDependencies": {
-    "babel-eslint": "^7.1.1",
-    "eslint": "^3.16.1",
-    "eslint-find-rules": "^1.14.3",
+    "babel-eslint": "^8.2.1",
+    "eslint": "^4.17.0",
+    "eslint-find-rules": "^3.2.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-mocha": "^4.7.0",
     "eslint-plugin-promise": "^3.3.1"


### PR DESCRIPTION
This is a breaking change, that will require updating the peer dependencies in code that uses it.

Also takes the opportunity to enforce `await`, and error for mocha arrows.

There will be a forthcoming `appium-gulp-plugins` PR that will also require changes to code that uses it, so putting them together makes sense (since it will require touching _everything_).