### PR TITLE
feat: add rules for arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ module.exports = {
     'comma-dangle': 0,
     'no-empty': 0,
     'object-shorthand': 2,
-    // 'arrow-parens': 2, // TODO: fix when they figure out async functions
+    'arrow-parens': [1, 'always'],
+    'arrow-body-style': [1, 'as-needed'],
     'import/export': 2,
     'import/no-unresolved': 2,
     'import/no-duplicates': 2,


### PR DESCRIPTION
Enforce (as warnings, for now) two situations:
1. if a fat-arrow function can be single line, with implicit return, use that
    ```diff
    --- a/index.js
    +++ b/index.js
    @@ -1,7 +1,5 @@
    function foo () {
    -  return () => {
    -    return `bar`;
    -  };
    +  return () => `bar`;
    }
    ```
1. parentheses around parameters for fat-arrow functions
    ```diff
    --- a/index.js
    +++ b/index.js
    @@ -1,5 +1,5 @@
    function foo () {
    -  return a => `bar: '${a}'`;
    +  return (a) => `bar: '${a}'`;
    }
```